### PR TITLE
Update lib/nssocket.js

### DIFF
--- a/lib/nssocket.js
+++ b/lib/nssocket.js
@@ -191,16 +191,18 @@ NsSocket.prototype.reconnect = function reconnect() {
       return self.emit('error', new Error('Did not reconnect after maximum retries: ' + self.retry.max));
     }
 
-    self.retry.waiting = true;
-
     // here for debugging reasons
     assert.isFalse(self.connected, 'before actually reconnect connected must be false');
     assert.isUndefined(self.socket, 'before actually reconnect socket must be destroied');
 
-    self.once('start', function () {
-      self.retry.waiting = false;
-      self.retry.retries = 0;
-    });
+    if (!self.retry.waiting) {
+      self.retry.waiting = true;
+
+      self.once('start', function () {
+        self.retry.waiting = false;
+        self.retry.retries = 0;
+      });
+    }
 
     self.connect.apply(self, self.connectionArgs);
   }, this.retry.wait);
@@ -279,6 +281,10 @@ function configureEvents(self) {
     }
 
     self.retry && self.reconnect();
+  });
+
+  self.stream.on('error', function (err) {
+    !self.retry && self.emit('error', err || new Error('An Unknown Error occured'));
   });
 
   self.socket.on('error', function (err) {


### PR DESCRIPTION
1) Using TLS, stream errors such as ECONNREFUSED were not catchable.
2) Connect retries would leak one 'start' listener each retry loop.
