### PR TITLE
Marking NsSocket as disconnected prior to firing "close" event

### DIFF
--- a/lib/nssocket.js
+++ b/lib/nssocket.js
@@ -456,6 +456,8 @@ NsSocket.prototype._onData = function _onData(message) {
 // actual error included by the underlying socket
 //
 NsSocket.prototype._onClose = function _onClose(hadError) {
+  this.connected = false;
+
   if (hadError) {
     this.emit('close', hadError, arguments[1]);
   }
@@ -463,7 +465,6 @@ NsSocket.prototype._onClose = function _onClose(hadError) {
     this.emit('close');
   }
 
-  this.connected = false;
   if (this._reconnect) {
     this.reconnect();
   }


### PR DESCRIPTION
When the underlying socket was disconnected, NsSocket would fire its "close" event prior to marking itself as disconnected via the `this.connected` property.  If the listener to the "close" event triggered downstream functions that attempted to call `nssocket.send`, they would not be able to tell that the socket is disconnected, and a low-level _net.js_ error would be thrown ("Error: This socket has been ended by the other party").
