### PR TITLE
fix #33

### DIFF
--- a/lib/nssocket.js
+++ b/lib/nssocket.js
@@ -58,6 +58,7 @@ var NsSocket = exports.NsSocket = function (socket, options) {
   //
   this._reconnect = options.reconnect  || false;
   this.retry      = {
+    closed:   true,
     retries:  0,
     max:      options.maxRetries || 10,
     interval: options.retryInterval || 5000,
@@ -205,6 +206,7 @@ NsSocket.prototype.setIdle = function setIdle(time) {
 // #### forcibly destroys this nsSocket, unregister socket, remove all callbacks
 //
 NsSocket.prototype.destroy = function destroy() {
+  this.retry.closed = true; // Disable reconnection logic
   if (this.socket) {
     try {
       this.socket.end(); // send FIN
@@ -229,6 +231,7 @@ NsSocket.prototype.destroy = function destroy() {
 //
 NsSocket.prototype.end = function end() {
   this.connected = false;
+  this.retry.closed = true; // Disable reconnection logic
 
   if (this.socket) {
     try {
@@ -279,6 +282,8 @@ NsSocket.prototype.connect = function connect(/*port, host, callback*/) {
   this.host = this.host || '127.0.0.1';
   args = this.port ? [this.port, this.host] : [this.host];
 
+  this.retry.closed = false;
+
   if (callback) {
     args.push(callback);
   }
@@ -308,6 +313,9 @@ NsSocket.prototype.connect = function connect(/*port, host, callback*/) {
 //
 NsSocket.prototype.reconnect = function reconnect() {
   var self = this;
+
+  // Do not try to reconnect when user requested disconnect
+  if(self.retry.closed) return;
 
   //
   // Helper function containing the core reconnect logic


### PR DESCRIPTION
Reconnect logic is now disabled when disconnect is by request (call to .end() or .destroy()).
This is not tested though, I don't have time for that. I may have missed some place where reconnect logic should be enabled back ( .retry.closed set to false ).