### PR TITLE
Fix simultaneous reconnection handling and exponential reconnection interval

### DIFF
--- a/lib/nssocket.js
+++ b/lib/nssocket.js
@@ -331,6 +331,7 @@ NsSocket.prototype.reconnect = function reconnect() {
     self.socket.once('connect', function () {
       self.retry.waiting = false;
       self.retry.retries = 0;
+      self._onStart();
     });
 
     //

--- a/lib/nssocket.js
+++ b/lib/nssocket.js
@@ -308,6 +308,9 @@ NsSocket.prototype.connect = function connect(/*port, host, callback*/) {
 //
 NsSocket.prototype.reconnect = function reconnect() {
   var self = this;
+  if(self.pendingReconnect)
+      return;
+  self.pendingReconnect = true;
 
   //
   // Helper function containing the core reconnect logic
@@ -341,6 +344,7 @@ NsSocket.prototype.reconnect = function reconnect() {
   // it is less than the maximum
   //
   function tryReconnect() {
+    self.pendingReconnect = false;
     self.retry.retries++;
     if (self.retry.retries >= self.retry.max) {
       return self.emit('error', new Error('Did not reconnect after maximum retries: ' + self.retry.max));

--- a/lib/nssocket.js
+++ b/lib/nssocket.js
@@ -321,15 +321,14 @@ NsSocket.prototype.reconnect = function reconnect() {
     // Cleanup and recreate the socket associated
     // with this instance.
     //
-    self.retry.waiting = true;
     self.socket.removeAllListeners();
     self.socket = common.createSocket(self._options);
+    self.retry.pendingReconnect = false;
 
     //
     // Cleanup reconnect logic once the socket connects
     //
     self.socket.once('connect', function () {
-      self.retry.waiting = false;
       self.retry.retries = 0;
       self._onStart();
     });
@@ -346,7 +345,6 @@ NsSocket.prototype.reconnect = function reconnect() {
   // it is less than the maximum
   //
   function tryReconnect() {
-    self.retry.pendingReconnect = false;
     self.retry.retries++;
     if (self.retry.max >= 0 && self.retry.retries >= self.retry.max) {
       return self.emit('error', new Error('Did not reconnect after maximum retries: ' + self.retry.max));
@@ -358,7 +356,9 @@ NsSocket.prototype.reconnect = function reconnect() {
   // retry interval follows a kind of Sigmoid function
   // it will be limited to 5 * (initial interval)
   this.retry.wait = this.retry.interval * (5 - 4*Math.pow(1.5, -this.retry.retries));
-  setTimeout(tryReconnect, this.retry.wait);
+  if(this.retry.reconnectTimeout)
+    clearTimeout(this.retry.reconnectTimeout);
+  this.retry.reconnectTimeout = setTimeout(tryReconnect, this.retry.wait * 1000);
 };
 
 //

--- a/lib/nssocket.js
+++ b/lib/nssocket.js
@@ -347,7 +347,7 @@ NsSocket.prototype.reconnect = function reconnect() {
   function tryReconnect() {
     self.retry.pendingReconnect = false;
     self.retry.retries++;
-    if (self.retry.retries >= self.retry.max) {
+    if (self.retry.max >= 0 && self.retry.retries >= self.retry.max) {
       return self.emit('error', new Error('Did not reconnect after maximum retries: ' + self.retry.max));
     }
 

--- a/lib/nssocket.js
+++ b/lib/nssocket.js
@@ -353,7 +353,7 @@ NsSocket.prototype.reconnect = function reconnect() {
     doReconnect();
   }
 
-  this.retry.wait = this.retry.interval * Math.pow(10, this.retry.retries);
+  this.retry.wait = this.retry.interval * (5 - 4*Math.pow(1.5, -this.retry.retries));
   setTimeout(tryReconnect, this.retry.wait);
 };
 

--- a/lib/nssocket.js
+++ b/lib/nssocket.js
@@ -61,7 +61,8 @@ var NsSocket = exports.NsSocket = function (socket, options) {
     retries:  0,
     max:      options.maxRetries || 10,
     interval: options.retryInterval || 5000,
-    wait:     options.retryInterval || 5000
+    wait:     options.retryInterval || 5000,
+    pendingReconnect: false
   };
 
   //
@@ -308,9 +309,9 @@ NsSocket.prototype.connect = function connect(/*port, host, callback*/) {
 //
 NsSocket.prototype.reconnect = function reconnect() {
   var self = this;
-  if(self.pendingReconnect)
+  if(self.retry.pendingReconnect)
       return;
-  self.pendingReconnect = true;
+  self.retry.pendingReconnect = true;
 
   //
   // Helper function containing the core reconnect logic
@@ -344,7 +345,7 @@ NsSocket.prototype.reconnect = function reconnect() {
   // it is less than the maximum
   //
   function tryReconnect() {
-    self.pendingReconnect = false;
+    self.retry.pendingReconnect = false;
     self.retry.retries++;
     if (self.retry.retries >= self.retry.max) {
       return self.emit('error', new Error('Did not reconnect after maximum retries: ' + self.retry.max));
@@ -353,6 +354,8 @@ NsSocket.prototype.reconnect = function reconnect() {
     doReconnect();
   }
 
+  // retry interval follows a kind of Sigmoid function
+  // it will be limited to 5 * (initial interval)
   this.retry.wait = this.retry.interval * (5 - 4*Math.pow(1.5, -this.retry.retries));
   setTimeout(tryReconnect, this.retry.wait);
 };


### PR DESCRIPTION
Hello,

I ran into an issue in which a 'close' and an 'error' event are fired simultaneously. Thus, 2 re-connections  are launched at the same time, and the second removes the listeners positioned on the socket by the first one.
This causes errors raised by the newly created socket not to be caught.

In this pull request, I fix this issue by rejecting a reconnection request if another one is pending.

I also fix the exponential reconnection interval : it is now limited to five times the initial interval.

Regards
